### PR TITLE
ENH: Fixed python3 incompatibilities

### DIFF
--- a/drawtree/__init__.py
+++ b/drawtree/__init__.py
@@ -1,7 +1,8 @@
+# -*- coding: utf-8 -*-
 """drawtree - Draw binary tree in plain text"""
 
 __version__ = '0.1.0'
 __author__ = 'Madhusudan Banik <msbanik@gmail.com>'
 __all__ = []
 
-from drawtree import draw_bst, draw_random_bst, draw_level_order
+from drawtree.drawtree import draw_bst, draw_random_bst, draw_level_order

--- a/drawtree/__init__.py
+++ b/drawtree/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """drawtree - Draw binary tree in plain text"""
+from __future__ import absolute_import
 
 __version__ = '0.1.0'
 __author__ = 'Madhusudan Banik <msbanik@gmail.com>'

--- a/drawtree/drawtree.py
+++ b/drawtree/drawtree.py
@@ -285,7 +285,7 @@ def drawtree(t):
     while (i < proot.height):
         print_next = 0
         print_level(proot, -xmin, i)
-        print()
+        print('')
         i += 1
 
     if proot.height >= MAX_HEIGHT:

--- a/drawtree/drawtree.py
+++ b/drawtree/drawtree.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import sys
 
 

--- a/drawtree/drawtree.py
+++ b/drawtree/drawtree.py
@@ -138,7 +138,7 @@ def compute_lprofile(node, x, y):
         return
 
     isleft = (node.parent_dir == -1)
-    lprofile[y] = min(lprofile[y], x - ((node.lablen - isleft) / 2))
+    lprofile[y] = min(lprofile[y], x - ((node.lablen - isleft) // 2))
     if node.left:
         i = 1
         while (i <= node.edge_length and y + i < MAX_HEIGHT):
@@ -154,7 +154,7 @@ def compute_rprofile(node, x, y):
         return
 
     notleft = (node.parent_dir != -1)
-    rprofile[y] = max(rprofile[y], x + ((node.lablen - notleft) / 2))
+    rprofile[y] = max(rprofile[y], x + ((node.lablen - notleft) // 2))
     if node.right is not None:
         i = 1
         while i <= node.edge_length and y + i < MAX_HEIGHT:
@@ -208,8 +208,7 @@ def compute_edge_lengths(node):
         if (((node.left is not None and node.left.height == 1) or (
                         node.right is not None and node.right.height == 1)) and delta > 4):
             delta -= 1
-        node.edge_length = ((delta + 1) / 2) - 1
-
+        node.edge_length = ((delta + 1) // 2) - 1
 
     # now fill in the height of node
     h = 1
@@ -233,7 +232,7 @@ def print_level(node, x, level):
         return
     isleft = (node.parent_dir == -1)
     if level == 0:
-        spaces = (x - print_next - ((node.lablen - isleft) / 2))
+        spaces = (x - print_next - ((node.lablen - isleft) // 2))
         sys.stdout.write(' ' * spaces)
 
         print_next += spaces
@@ -286,11 +285,11 @@ def drawtree(t):
     while (i < proot.height):
         print_next = 0
         print_level(proot, -xmin, i)
-        print
+        print()
         i += 1
 
     if proot.height >= MAX_HEIGHT:
-        print "This tree is taller than %d, and may be drawn incorrectly.".format(MAX_HEIGHT)
+        print(("This tree is taller than %d, and may be drawn incorrectly.".format(MAX_HEIGHT)))
 
 
 def deserialize(string):
@@ -302,8 +301,10 @@ def deserialize(string):
     root = kids.pop()
     for node in nodes:
         if node:
-            if kids: node.left = kids.pop()
-            if kids: node.right = kids.pop()
+            if kids:
+                node.left = kids.pop()
+            if kids:
+                node.right = kids.pop()
     return root
 
 


### PR DESCRIPTION
I changed the `__init__.py` to use absolute imports and added the required `__future__` import for python2 backwards compatibility. 

I changed print statements to print functions.  

I changed ambiguous division to integer division.

After these changes I'm now able to use the library in python3. 